### PR TITLE
Update for Dart2, Angular  v5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ doc/api/
 *.iml
 *.ipr
 *.iws
+
+.dart_tool/

--- a/lib/src/SweetAlert.dart
+++ b/lib/src/SweetAlert.dart
@@ -5,10 +5,8 @@
 import 'dart:js' as js;
 
 class SweetAlert {
-
   static void swal(String title,
-      {
-      String text,
+      {String text,
       String type,
       bool allowEscapeKey,
       String customClass,
@@ -30,7 +28,7 @@ class SweetAlert {
       String inputValue,
       bool showLoaderOnConfirm,
       Function callback}) {
-    var options = { 'title': title};
+    Map<String, dynamic> options = {'title': title};
     if (text != null) {
       options['text'] = text;
     }
@@ -103,29 +101,28 @@ class SweetAlert {
     js.context.callMethod("swal", args);
   }
 
-  static void setDefaults({
-  String text,
-  String type,
-  bool allowEscapeKey,
-  String customClass,
-  bool allowOutsideClick,
-  bool showCancelButton,
-  bool showConfirmButton,
-  String confirmButtonText,
-  String confirmButtonColor,
-  String cancelButtonText,
-  bool closeOnConfirm,
-  bool closeOnCancel,
-  String imageUrl,
-  String imageSize,
-  int timer,
-  bool html,
-  String animation,
-  String inputType,
-  String inputPlaceholder,
-  String inputValue,
-  bool showLoaderOnConfirm
-  }) {
+  static void setDefaults(
+      {String text,
+      String type,
+      bool allowEscapeKey,
+      String customClass,
+      bool allowOutsideClick,
+      bool showCancelButton,
+      bool showConfirmButton,
+      String confirmButtonText,
+      String confirmButtonColor,
+      String cancelButtonText,
+      bool closeOnConfirm,
+      bool closeOnCancel,
+      String imageUrl,
+      String imageSize,
+      int timer,
+      bool html,
+      String animation,
+      String inputType,
+      String inputPlaceholder,
+      String inputValue,
+      bool showLoaderOnConfirm}) {
     var options = {};
     if (text != null) {
       options['text'] = text;
@@ -191,8 +188,8 @@ class SweetAlert {
       options['showLoaderOnConfirm'] = showLoaderOnConfirm;
     }
 
-    js.context["swal"].callMethod(
-        "setDefaults", [new js.JsObject.jsify(options)]);
+    js.context["swal"]
+        .callMethod("setDefaults", [new js.JsObject.jsify(options)]);
   }
 
   static void close() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sweetalert_angular_dart
 description: SweetAlert for Angular Dart
-version: 0.3.0
+version: 0.3.1
 author: Nick Ng <ngyewch@gmail.com>
 homepage: https://github.com/ngyewch/sweetalert-angular-dart
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,12 +5,12 @@ author: Nick Ng <ngyewch@gmail.com>
 homepage: https://github.com/ngyewch/sweetalert-angular-dart
 
 environment:
-  sdk: '>=1.23.0 <2.0.0'
+  sdk: '>=2.0.0 <3.0.0'
+
 
 dependencies:
-  angular: '>=4.0.0 <5.0.0'
-  browser: '>=0.10.0 <0.11.0'
+  angular: '>=5.0.0 <6.0.0'
+  build_runner: '>=0.8.10 <0.11.0'
 
-transformers:
-- angular:
-    entry_points: web/main.dart
+dev_dependencies:
+  build_web_compilers: '>=0.3.6 <0.5.0'

--- a/web/analysis_options.yaml
+++ b/web/analysis_options.yaml
@@ -1,0 +1,19 @@
+analyzer:
+  exclude: [build/**]
+  errors:
+    uri_has_not_been_generated: ignore
+  # Angular plugin support is in beta. You're welcome to try it and report
+  # issues: https://github.com/dart-lang/angular_analyzer_plugin/issues
+  # plugins:
+    # - angular
+
+# Lint rules and documentation, see http://dart-lang.github.io/linter/lints
+linter:
+  rules:
+    - cancel_subscriptions
+    - hash_and_equals
+    - iterable_contains_unrelated_type
+    - list_remove_unrelated_type
+    - test_types_in_equals
+    - unrelated_type_equality_checks
+    - valid_regexps

--- a/web/index.html
+++ b/web/index.html
@@ -10,8 +10,7 @@
 
     <script type="text/javascript" src="packages/sweetalert_angular_dart/sweetalert-dev.js"></script>
 
-    <script defer src="main.dart" type="application/dart"></script>
-    <script defer src="packages/browser/dart.js"></script>
+    <script defer src="main.dart.js"></script>
 
 	<script>
 	  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/web/main.dart
+++ b/web/main.dart
@@ -1,7 +1,7 @@
 import 'package:angular/angular.dart';
 
-import 'AppComponent.dart';
+import 'AppComponent.template.dart' as ng;
 
 main() {
-  bootstrap(AppComponent);
+  runApp(ng.AppComponentNgFactory);
 }


### PR DESCRIPTION
In order for this library  to work with Dart2, one minor change had to be made: changing the dynamic type for options into `Map<String, dynamic>`. I've also updated the example to compile and serve with webdev (as required by Angular v5.)